### PR TITLE
chore: match currency to TICKER across languages

### DIFF
--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -15,7 +15,7 @@
     "copy.tooltip": "Kopieren",
     "error": "Error",
     "close": "close",
-    "currency": "qus",
+    "currency": "QUBIC",
     "currentTick": "Aktueller Tick: {{tick}}",
     "loading": "loading..."
   },

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -14,7 +14,7 @@
         "version.url": "qubic.li",
         "error": "Error",
         "close": "close",
-        "currency": "qus",
+        "currency": "QUBIC",
         "currentTick": "Current Tick: {{tick}}",
         "loading": "cargando..."
     },

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -15,7 +15,7 @@
         "copy.tooltip": "Copy",
         "error": "Error",
         "close": "sluiten",
-        "currency": "qus",
+        "currency": "QUBIC",
         "currentTick": "Huidige Tick: {{tick}}",
         "loading": "loading..."
     },

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -15,7 +15,7 @@
     "copy.tooltip": "Копировать",
     "error": "Ошибка",
     "close": "Закрыть",
-    "currency": "qus",
+    "currency": "QUBIC",
     "currentTick": "Current Tick: {{tick}}",
     "loading": "loading..."
   },


### PR DESCRIPTION
Matches en.json's https://github.com/qubic-li/wallet/blob/main/src/assets/i18n/en.json#L18

Was unsure of changing the rest of the `qus`.


This one in particular I found offputting when helping someone through the visual wallet issue.
Couldn't find `KUBIK` though? (might be a translation extension)
![image](https://github.com/qubic-li/wallet/assets/3268868/a091bdf3-7339-4758-9311-60518ac301f6)

