### PR TITLE
fix: copy address on reveal seed page

### DIFF
--- a/src/app/main/reveal-seed/reveal-seed.component.html
+++ b/src/app/main/reveal-seed/reveal-seed.component.html
@@ -1,9 +1,9 @@
 <ng-container *transloco="let t">
 <h2 mat-dialog-title>{{t("revealSeedComponent.title")}}</h2>
 <mat-dialog-content>
-      <div class="seedInput" [cdkCopyToClipboard]="s">
+      <div class="seedInput">
         <strong>{{t("revealSeedComponent.publicId")}}</strong>
-        <div class="copy" [matTooltip]="t('general.copy.tooltip')" [cdkCopyToClipboard]="s">
+        <div class="copy" [matTooltip]="t('general.copy.tooltip')" [cdkCopyToClipboard]="data.publicId">
           {{data.publicId}}
         </div>
         <strong>{{t("revealSeedComponent.privateId")}}</strong>


### PR DESCRIPTION
Allows you to copy both the Address and Seed individually on the reveal page.

![image](https://github.com/qubic-li/wallet/assets/3268868/3de0af89-5438-473f-b5e6-3254057048db)

1. Click top blue -> Copies the Address
2. Click bottom blue -> Copies the Seed